### PR TITLE
Update Minecraft Wiki link to new domain after fork

### DIFF
--- a/utils/get_block_list.py
+++ b/utils/get_block_list.py
@@ -5,7 +5,7 @@ import re
 
 import requests
 
-txt = requests.get(r'https://minecraft.fandom.com/api.php?action=parse&format=json&prop=text%7Cmodules%7Cjsconfigvars&title=Java_Edition_data_values&text=%7B%7B%3AJava%20Edition%20data%20values%2FBlocks%7D%7D').text
+txt = requests.get(r'https://minecraft.wiki/api.php?action=parse&format=json&prop=text%7Cmodules%7Cjsconfigvars&title=Java_Edition_data_values&text=%7B%7B%3AJava%20Edition%20data%20values%2FBlocks%7D%7D').text
 
 blocks = re.findall('<code>(\w+?)<\/code>', txt)
 


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom.